### PR TITLE
Add `config_local`, `data_local`, `fonts`, and `preferences` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+### Added
+
+* `config_local()` - Returns user's local (non-roaming) config directory. On Windows uses `%LOCALAPPDATA%`, identical
+  to `config_home()` on other platforms
+* `data_local()` - Returns user's local (non-roaming) data directory. On Windows uses `%LOCALAPPDATA%`, identical to
+  `data_home()` on other platforms
+* `fonts()` - Returns user's fonts directory
+  (`~/.local/share/fonts` on Linux, `~/Library/Fonts` on macOS, `None` on Windows)
+* `preferences()` - Returns user's preferences directory. On macOS returns `~/Library/Preferences` for .plist files,
+  identical to `config_home()` on other platforms
+
 ## [0.2.0] - 2025-08-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,42 +31,73 @@ Basic usage:
 use dir_spec::Dir;
 
 fn main() {
-    // Get config directory (respects XDG_CONFIG_HOME if set)
-    if let Some(config_dir) = Dir::config_home() {
-        println!("Config: {}", config_dir.display());
-    }
-    
-    // Get cache directory (respects XDG_CACHE_HOME if set)
-    if let Some(cache_dir) = Dir::cache_home() {
-        println!("Cache: {}", cache_dir.display());
-    }
-    
-    // Get user's home directory
-    if let Some(home_dir) = Dir::home() {
-        println!("Home: {}", home_dir.display());
-    }
+  // Get config directory (respects XDG_CONFIG_HOME if set)
+  if let Some(config_dir) = Dir::config_home() {
+    println!("Config: {}", config_dir.display());
+  }
+
+  // Get cache directory (respects XDG_CACHE_HOME if set)
+  if let Some(cache_dir) = Dir::cache_home() {
+    println!("Cache: {}", cache_dir.display());
+  }
+
+  // Get user's home directory
+  if let Some(home_dir) = Dir::home() {
+    println!("Home: {}", home_dir.display());
+  }
 }
 ```
 
 ## Supported Directories
 
-| Method          | XDG Variable           | Linux Default        | macOS Default                    | Windows Default             |
-|-----------------|------------------------|----------------------|----------------------------------|-----------------------------|
-| `bin_home()`    | `XDG_BIN_HOME`         | `~/.local/bin`       | `~/.local/bin`                   | `%LOCALAPPDATA%\Programs`   |
-| `cache_home()`  | `XDG_CACHE_HOME`       | `~/.cache`           | `~/Library/Caches`               | `%LOCALAPPDATA%`            |
-| `config_home()` | `XDG_CONFIG_HOME`      | `~/.config`          | `~/Library/Application Support`  | `%APPDATA%`                 |
-| `data_home()`   | `XDG_DATA_HOME`        | `~/.local/share`     | `~/Library/Application Support`  | `%APPDATA%`                 |
-| `desktop()`     | `XDG_DESKTOP_DIR`      | `~/Desktop`          | `~/Desktop`                      | `%USERPROFILE%\Desktop`     |
-| `documents()`   | `XDG_DOCUMENTS_DIR`    | `~/Documents`        | `~/Documents`                    | `%USERPROFILE%\Documents`   |
-| `downloads()`   | `XDG_DOWNLOAD_DIR`     | `~/Downloads`        | `~/Downloads`                    | `%USERPROFILE%\Downloads`   |
-| `music()`       | `XDG_MUSIC_DIR`        | `~/Music`            | `~/Music`                        | `%USERPROFILE%\Music`       |
-| `pictures()`    | `XDG_PICTURES_DIR`     | `~/Pictures`         | `~/Pictures`                     | `%USERPROFILE%\Pictures`    |
-| `publicshare()` | `XDG_PUBLICSHARE_DIR`  | `~/Public`           | `~/Public`                       | `C:\Users\Public`           |
-| `runtime()`     | `XDG_RUNTIME_DIR`      | `$TMPDIR` or `/tmp`  | `$TMPDIR` or `/tmp`              | `%TEMP%`                    |
-| `state_home()`  | `XDG_STATE_HOME`       | `~/.local/state`     | `~/Library/Application Support`  | `%LOCALAPPDATA%`            |
-| `templates()`   | `XDG_TEMPLATES_DIR`    | `~/Templates`        | `~/Templates`                    | `%USERPROFILE%\Templates`   |
-| `videos()`      | `XDG_VIDEOS_DIR`       | `~/Videos`           | `~/Movies`                       | `%USERPROFILE%\Videos`      |
-| `home()`        | `HOME` / `USERPROFILE` | `$HOME`              | `$HOME`                          | `%USERPROFILE%`             |
+| Method            | XDG Variable           | Linux Default        | macOS Default                    | Windows Default             |
+|-------------------|------------------------|----------------------|----------------------------------|-----------------------------|
+| `bin_home()`      | `XDG_BIN_HOME`         | `~/.local/bin`       | `~/.local/bin`                   | `%LOCALAPPDATA%\Programs`   |
+| `cache_home()`    | `XDG_CACHE_HOME`       | `~/.cache`           | `~/Library/Caches`               | `%LOCALAPPDATA%`            |
+| `config_home()`   | `XDG_CONFIG_HOME`      | `~/.config`          | `~/Library/Application Support`  | `%APPDATA%`                 |
+| `config_local()`  | —                      | `~/.config`¹         | `~/Library/Application Support`¹ | `%LOCALAPPDATA%`            |
+| `data_home()`     | `XDG_DATA_HOME`        | `~/.local/share`     | `~/Library/Application Support`  | `%APPDATA%`                 |
+| `data_local()`    | —                      | `~/.local/share`¹    | `~/Library/Application Support`¹ | `%LOCALAPPDATA%`            |
+| `desktop()`       | `XDG_DESKTOP_DIR`      | `~/Desktop`          | `~/Desktop`                      | `%USERPROFILE%\Desktop`     |
+| `documents()`     | `XDG_DOCUMENTS_DIR`    | `~/Documents`        | `~/Documents`                    | `%USERPROFILE%\Documents`   |
+| `downloads()`     | `XDG_DOWNLOAD_DIR`     | `~/Downloads`        | `~/Downloads`                    | `%USERPROFILE%\Downloads`   |
+| `fonts()`         | —                      | `~/.local/share/fonts` | `~/Library/Fonts`              | `None`²                     |
+| `home()`          | `HOME` / `USERPROFILE` | `$HOME`              | `$HOME`                          | `%USERPROFILE%`             |
+| `music()`         | `XDG_MUSIC_DIR`        | `~/Music`            | `~/Music`                        | `%USERPROFILE%\Music`       |
+| `pictures()`      | `XDG_PICTURES_DIR`     | `~/Pictures`         | `~/Pictures`                     | `%USERPROFILE%\Pictures`    |
+| `preferences()`   | —                      | `~/.config`¹         | `~/Library/Preferences`          | `%APPDATA%`¹                |
+| `publicshare()`   | `XDG_PUBLICSHARE_DIR`  | `~/Public`           | `~/Public`                       | `C:\Users\Public`           |
+| `runtime()`       | `XDG_RUNTIME_DIR`      | `$TMPDIR` or `/tmp`  | `$TMPDIR` or `/tmp`              | `%TEMP%`                    |
+| `state_home()`    | `XDG_STATE_HOME`       | `~/.local/state`     | `~/Library/Application Support`  | `%LOCALAPPDATA%`            |
+| `templates()`     | `XDG_TEMPLATES_DIR`    | `~/Templates`        | `~/Templates`                    | `%USERPROFILE%\Templates`   |
+| `videos()`        | `XDG_VIDEOS_DIR`       | `~/Videos`           | `~/Movies`                       | `%USERPROFILE%\Videos`      |
+
+**Notes:**
+
+1. Same as the corresponding `*_home()` function on non-Windows platforms
+2. Returns `None` on Windows as there is no standard user fonts directory
+
+## Directory Types Explained
+
+### Config vs. Config Local
+
+- **`config_home()`**: Roaming config directory (synced across machines on Windows)
+- **`config_local()`**: Local config directory (machine-specific, not synced)
+
+### Data vs. Data Local
+
+- **`data_home()`**: Roaming data directory (synced across machines on Windows)
+- **`data_local()`**: Local data directory (machine-specific, not synced)
+
+### Config vs. Preferences
+
+- **`config_home()`**: General application configuration
+- **`preferences()`**: Platform-specific preferences (macOS: `.plist` files via Apple APIs)
+
+### Fonts
+
+- **`fonts()`**: User-installed fonts directory
+- Returns `None` on Windows as there's no standard user fonts directory
 
 ## XDG Environment Variable Priority
 
@@ -92,12 +123,15 @@ Follows XDG Base Directory Specification defaults when XDG variables aren't set.
 - Respects XDG variables if set (common among CLI tool users)
 - Falls back to native macOS locations (`~/Library/Application Support`, etc.)
 - Uses `~/Movies` for videos (not `~/Videos`)
+- `preferences()` points to `~/Library/Preferences` for `.plist` files
 
 ### Windows
 
 - Respects XDG variables if set
 - Falls back to Windows conventions (`%APPDATA%`, `%LOCALAPPDATA%`, etc.)
 - Public directory points to system-wide `C:\Users\Public`
+- `config_local()` and `data_local()` use `%LOCALAPPDATA%` for non-roaming storage
+- `fonts()` returns `None` (no standard user fonts directory)
 
 ## Error Handling
 
@@ -106,6 +140,7 @@ All methods return `Option<PathBuf>`. Methods return `None` when:
 - Home directory cannot be determined
 - Required environment variables are missing (Windows-specific cases)
 - Platform-specific directory resolution fails
+- Directory doesn't exist on the platform (e.g., `fonts()` on Windows)
 
 ```rust
 match Dir::config_home() {
@@ -123,31 +158,6 @@ let config_dir = Dir::config_home().unwrap_or_else(|| {
     // Fallback to current directory or panic, depending on your needs
     std::env::current_dir().expect("Cannot determine current directory")
 });
-```
-
-## Migration from 0.1.x
-
-Version 0.2.0 introduces breaking changes:
-
-- **Return type changed**: Methods now return `Option<PathBuf>` instead of `Result<PathBuf>`
-- **Removed deprecated methods**: All `*_dir()` variants have been removed
-- **No more eyre dependency**: Simpler error handling with Options
-
-Migration guide:
-
-```rust
-// 0.1.x
-let config = Dir::config_home()?;
-let desktop = Dir::desktop_dir()?;
-
-// 0.2.x
-let config = Dir::config_home().ok_or("Failed to get config dir")?;
-let desktop = Dir::desktop().ok_or("Failed to get desktop dir")?;
-
-// Or using if-let
-if let Some(config) = Dir::config_home() {
-    // use config
-}
 ```
 
 ## Dependencies
@@ -175,5 +185,5 @@ Contributions are welcome! Please ensure:
 
 [xdg-spec]: https://specifications.freedesktop.org/basedir-spec/latest/
 [apple-guide]:
-  https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/
+https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/
 [windows-folders]: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid


### PR DESCRIPTION
## Summary

- Introduce `config_local()` for non-roaming config directory resolution.
- Add `data_local()` for non-roaming data directory resolution.
- Add `fonts()` for user-installed fonts directory retrieval.
- Add `preferences()` for platform-specific preferences directory.

Update README, CHANGELOG, and tests to reflect the new functionality.

## Type of Change

<!-- Mark with an `x` all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code cleanup or refactoring
- [ ] 🔧 Build system or dependency changes
- [ ] 🧪 Test improvements

## What Changed?

* `config_local()` - Returns user's local (non-roaming) config directory. On Windows uses `%LOCALAPPDATA%`, identical
  to `config_home()` on other platforms
* `data_local()` - Returns user's local (non-roaming) data directory. On Windows uses `%LOCALAPPDATA%`, identical to
  `data_home()` on other platforms
* `fonts()` - Returns user's fonts directory
  (`~/.local/share/fonts` on Linux, `~/Library/Fonts` on macOS, `None` on Windows)
* `preferences()` - Returns user's preferences directory. On macOS returns `~/Library/Preferences` for .plist files,
  identical to `config_home()` on other platforms

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Existing tests pass (`mise test`)
- [x] New tests added for new functionality
- [x] Manual testing performed
- [x] Code follows style guidelines (`mise lint`)
