### PR TITLE
Modularize platform-specific directory resolution in `Dir`

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,76 @@
+use std::{env, path::PathBuf};
+
+use crate::xdg;
+
+pub fn bin_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::BIN_HOME, ".local/bin")
+}
+
+pub fn cache_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::CACHE_HOME, ".cache")
+}
+
+pub fn config_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::CONFIG_HOME, ".config")
+}
+
+pub fn config_local() -> Option<PathBuf> {
+  config_home()
+}
+
+pub fn data_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DATA_HOME, ".local/share")
+}
+
+pub fn data_local() -> Option<PathBuf> {
+  data_home()
+}
+
+pub fn desktop() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DESKTOP_DIR, "Desktop")
+}
+
+pub fn documents() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DOCUMENTS_DIR, "Documents")
+}
+
+pub fn downloads() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DOWNLOAD_DIR, "Downloads")
+}
+
+pub fn fonts() -> Option<PathBuf> {
+  env::home_dir().map(|p| p.join(".local/share/fonts"))
+}
+
+pub fn music() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::MUSIC_DIR, "Music")
+}
+
+pub fn pictures() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::PICTURES_DIR, "Pictures")
+}
+
+pub fn preferences() -> Option<PathBuf> {
+  config_home()
+}
+
+pub fn publicshare() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::PUBLICSHARE_DIR, "Public")
+}
+
+pub fn runtime() -> Option<PathBuf> {
+  xdg::resolve_path(xdg::RUNTIME_DIR)
+    .or_else(|| env::var("TMPDIR").ok().map(PathBuf::from).or_else(|| Some(PathBuf::from("/tmp"))))
+}
+
+pub fn state_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::STATE_HOME, ".local/state")
+}
+
+pub fn templates() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::TEMPLATES_DIR, "Templates")
+}
+
+pub fn videos() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::VIDEOS_DIR, "Videos")
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,78 @@
+use std::{env, path::PathBuf};
+
+use crate::xdg;
+
+const APP_SUPPORT: &str = "Library/Application Support";
+
+pub fn bin_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::BIN_HOME, ".local/bin")
+}
+
+pub fn cache_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::CACHE_HOME, "Library/Caches")
+}
+
+pub fn config_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::CONFIG_HOME, APP_SUPPORT)
+}
+
+pub fn config_local() -> Option<PathBuf> {
+  config_home()
+}
+
+pub fn data_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DATA_HOME, APP_SUPPORT)
+}
+
+pub fn data_local() -> Option<PathBuf> {
+  data_home()
+}
+
+pub fn desktop() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DESKTOP_DIR, "Desktop")
+}
+
+pub fn documents() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DOCUMENTS_DIR, "Documents")
+}
+
+pub fn downloads() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::DOWNLOAD_DIR, "Downloads")
+}
+
+pub fn fonts() -> Option<PathBuf> {
+  env::home_dir().map(|p| p.join("Library/Fonts"))
+}
+
+pub fn music() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::MUSIC_DIR, "Music")
+}
+
+pub fn pictures() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::PICTURES_DIR, "Pictures")
+}
+
+pub fn preferences() -> Option<PathBuf> {
+  env::home_dir().map(|p| p.join("Library/Preferences"))
+}
+
+pub fn publicshare() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::PUBLICSHARE_DIR, "Public")
+}
+
+pub fn runtime() -> Option<PathBuf> {
+  xdg::resolve_path(xdg::RUNTIME_DIR)
+    .or_else(|| env::var("TMPDIR").ok().map(PathBuf::from).or_else(|| Some(PathBuf::from("/tmp"))))
+}
+
+pub fn state_home() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::STATE_HOME, APP_SUPPORT)
+}
+
+pub fn templates() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::TEMPLATES_DIR, "Templates")
+}
+
+pub fn videos() -> Option<PathBuf> {
+  xdg::resolve_path_with_fallback(xdg::VIDEOS_DIR, "Movies")
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,91 @@
+use std::{env, path::PathBuf};
+
+use crate::xdg;
+
+const APPDATA: &str = "APPDATA";
+const LOCALAPPDATA: &str = "LOCALAPPDATA";
+const USERPROFILE: &str = "USERPROFILE";
+
+pub fn bin_home() -> Option<PathBuf> {
+  resolve_path(LOCALAPPDATA).map(|p| p.join("Programs"))
+}
+
+pub fn cache_home() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback(xdg::CACHE_HOME, LOCALAPPDATA)
+}
+
+pub fn config_home() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback(xdg::CONFIG_HOME, APPDATA)
+}
+
+pub fn config_local() -> Option<PathBuf> {
+  resolve_path(LOCALAPPDATA)
+}
+
+pub fn data_home() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback(xdg::DATA_HOME, APPDATA)
+}
+
+pub fn data_local() -> Option<PathBuf> {
+  env::var_os(LOCALAPPDATA).map(PathBuf::from)
+}
+
+pub fn desktop() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback_and_sub_dir(xdg::DESKTOP_DIR, USERPROFILE, "Desktop")
+}
+
+pub fn documents() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback_and_sub_dir(xdg::DOCUMENTS_DIR, USERPROFILE, "Documents")
+}
+
+pub fn downloads() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback_and_sub_dir(xdg::DOWNLOAD_DIR, USERPROFILE, "Downloads")
+}
+
+pub fn fonts() -> Option<PathBuf> {
+  None
+}
+
+pub fn music() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback_and_sub_dir(xdg::MUSIC_DIR, USERPROFILE, "Music")
+}
+
+pub fn pictures() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback_and_sub_dir(xdg::PICTURES_DIR, USERPROFILE, "Pictures")
+}
+
+pub fn preferences() -> Option<PathBuf> {
+  config_home()
+}
+
+pub fn publicshare() -> Option<PathBuf> {
+  Some(PathBuf::from("C:\\Users\\Public"))
+}
+
+pub fn runtime() -> Option<PathBuf> {
+  env::var_os("TEMP").map(PathBuf::from)
+}
+
+pub fn state_home() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback(xdg::STATE_HOME, LOCALAPPDATA)
+}
+
+pub fn templates() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback_and_sub_dir(xdg::TEMPLATES_DIR, USERPROFILE, "Templates")
+}
+
+pub fn videos() -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback_and_sub_dir(xdg::VIDEOS_DIR, USERPROFILE, "Videos")
+}
+
+fn resolve_path(key: &str) -> Option<PathBuf> {
+  env::var_os(key).map(PathBuf::from)
+}
+
+fn resolve_xdg_path_with_fallback(xdg_key: &str, key: &str) -> Option<PathBuf> {
+  xdg::resolve_path(xdg_key).or_else(|| env::var_os(key).map(PathBuf::from))
+}
+
+fn resolve_xdg_path_with_fallback_and_sub_dir(xdg_key: &str, key: &str, sub_dir: &str) -> Option<PathBuf> {
+  resolve_xdg_path_with_fallback(xdg_key, key).map(|p| p.join(sub_dir))
+}

--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -1,0 +1,24 @@
+use std::{env, path::PathBuf};
+
+pub const BIN_HOME: &str = "XDG_BIN_HOME";
+pub const CACHE_HOME: &str = "XDG_CACHE_HOME";
+pub const CONFIG_HOME: &str = "XDG_CONFIG_HOME";
+pub const DATA_HOME: &str = "XDG_DATA_HOME";
+pub const DESKTOP_DIR: &str = "XDG_DESKTOP_DIR";
+pub const DOCUMENTS_DIR: &str = "XDG_DOCUMENTS_DIR";
+pub const DOWNLOAD_DIR: &str = "XDG_DOWNLOAD_DIR";
+pub const MUSIC_DIR: &str = "XDG_MUSIC_DIR";
+pub const PICTURES_DIR: &str = "XDG_PICTURES_DIR";
+pub const PUBLICSHARE_DIR: &str = "XDG_PUBLICSHARE_DIR";
+pub const RUNTIME_DIR: &str = "XDG_RUNTIME_DIR";
+pub const STATE_HOME: &str = "XDG_STATE_HOME";
+pub const TEMPLATES_DIR: &str = "XDG_TEMPLATES_DIR";
+pub const VIDEOS_DIR: &str = "XDG_VIDEOS_DIR";
+
+pub fn resolve_path(key: &str) -> Option<PathBuf> {
+  env::var_os(key).map(PathBuf::from).filter(|p| p.is_absolute())
+}
+
+pub fn resolve_path_with_fallback(key: &str, default: &str) -> Option<PathBuf> {
+  resolve_path(key).or_else(|| env::home_dir().map(|p| p.join(default)))
+}


### PR DESCRIPTION
## Summary

Refactor `Dir` to delegate directory resolution to platform-specific modules (`linux`, `macos`, `windows`) for improved code organization.

- Move XDG logic into a new `xdg` module.
- Implement platform-specific behavior in separate modules.
- Replace platform-dependent code in `Dir` with calls to unified interfaces (`os::*`).
- Simplify XDG variable resolution and fallback mechanisms.

Enables easier extensibility and maintenance by isolating platform-specific logic.

## Type of Change

<!-- Mark with an `x` all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🧹 Code cleanup or refactoring
- [ ] 🔧 Build system or dependency changes
- [ ] 🧪 Test improvements

## What Changed?

- Extracted XDG Base Directory Specification logic into a dedicated `xdg.rs` module with `resolve_path()` and `resolve_path_with_fallback()` functions
- Created platform-specific modules:
  - `linux.rs` - Linux-specific directory implementations
  - `macos.rs` - macOS-specific directory implementations  
  - `windows.rs` - Windows-specific directory implementations
- Replaced inline conditional compilation (`#[cfg(target_os = "...")]`) scattered throughout `lib.rs` with clean module delegation using `use platform as os`
- Consolidated platform-specific helper functions within their respective modules
- Maintained identical public API - all existing function signatures remain unchanged

## Why?

The previous single-file approach had several maintainability issues:
- Platform-specific logic was scattered across every public method with `#[cfg]` blocks
- Difficult to locate and modify behavior for a specific platform
- Code duplication in helper functions trying to abstract conditional compilation
- Poor readability due to nested conditional compilation throughout functions
- Hard to test platform-specific logic in isolation

This refactor follows Rust best practices for platform-specific code organization, similar to how the standard library handles cross-platform differences.

## How Has This Been Tested?

- [x] Existing tests pass (`mise test`)
- [ ] New tests added for new functionality
- [x] Manual testing performed
- [x] Code follows style guidelines (`mise lint`)

All existing tests continue to pass, ensuring no behavioral changes. The refactor is purely organizational - the public API and functionality remain identical.


## Additional Notes

This refactor makes the codebase significantly easier to maintain and extend:
- Adding support for new platforms now only requires creating a new module file
- Platform-specific bugs can be fixed by editing a single, focused file
- Each platform's logic is self-contained and easier to understand
- Follows established Rust conventions for cross-platform libraries

The change is completely backwards compatible - no breaking changes to the public API.